### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-validation.yml
+++ b/.github/workflows/docker-validation.yml
@@ -214,6 +214,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-docker-files
     if: success()
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/KodoHub/UchuDocs/security/code-scanning/3](https://github.com/KodoHub/UchuDocs/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the `Test Docker Build` job. This block should specify the minimal permissions required for the job to function correctly. Based on the job's functionality, it only needs read access to the repository contents. Therefore, the `permissions` block should be set to `contents: read`.

The `permissions` block should be added directly under the job definition (`test-docker-build`) in the `.github/workflows/docker-validation.yml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
