### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-validation.yml
+++ b/.github/workflows/docker-validation.yml
@@ -18,6 +18,8 @@ jobs:
   validate-docker-files:
     name: Validate Docker Configuration Files
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/KodoHub/UchuDocs/security/code-scanning/2](https://github.com/KodoHub/UchuDocs/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the `validate-docker-files` job. Since this job only reads files and validates their contents, the minimal required permission is `contents: read`. This change ensures that the job does not inherit unnecessary write permissions from the repository's default settings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
